### PR TITLE
fixed(frontend:totp): totp 列表多时，创建按钮会被覆盖

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### fixed
 
 - fixed(frontend:totp): totp 创建后未自动刷新列表(#15)
+- fixed(frontend:totp): totp 列表多时，创建按钮会被覆盖(#18)
 
 ## v1.1.2
 

--- a/miniprogram/pages/totp/index.scss
+++ b/miniprogram/pages/totp/index.scss
@@ -74,6 +74,7 @@
 }
 
 .footer {
+  z-index: 99999;
   height: 50px;
   width: 100%;
   background-color: rgb(241, 243, 255);


### PR DESCRIPTION
fix: #17 